### PR TITLE
WIP: Overhauling the state management system

### DIFF
--- a/src/main/resources/logback-test.xml
+++ b/src/main/resources/logback-test.xml
@@ -23,6 +23,7 @@
   <logger name="info.vizierdb.catalog.Module"                    level="DEBUG" />
   <logger name="info.vizierdb.viztrails.Scheduler$"              level="TRACE" />
   <logger name="info.vizierdb.viztrails.Provenance$"             level="WARN" />
+  <logger name="info.vizierdb.viztrails.StateTransition$"        level="WARN" />
   <logger name="info.vizierdb.api.websocket.BranchWatcherSocket" level="TRACE" />
 
   <!--+++++++++++++++++++++++  Commands  +++++++++++++++++++++++++-->

--- a/src/main/scala/info/vizierdb/Vizier.scala
+++ b/src/main/scala/info/vizierdb/Vizier.scala
@@ -55,7 +55,19 @@ object Vizier
       settings = ConnectionPoolSettings(
         initialSize = 1,
         maxSize = 1,
-        connectionTimeoutMillis = 5000l
+
+        // If you are here to up the connection time-out period because you're getting connection
+        // timeouts, read this first please:
+        //
+        // https://github.com/VizierDB/vizier-scala/wiki/DevGuide-Gotchas#scalikejdbc
+        //
+        // TL;DR: You are almost certainly creating a nested session via DB.readOnly or 
+        //        DB.autocommit  Look through the stack trace.  These methods are NOT reentrant,
+        //        will trigger a connection timeout error when you're using SQLite, and will lead
+        //        to weird inconsistent state when you're using a database that allows parallel
+        //        connections.
+        /* ^^^^^ */ connectionTimeoutMillis = 5000l  /* ^^^^^ */
+        // Read the above comment before modifying connectionTimeoutMillis please.
       )
     )
   }

--- a/src/main/scala/info/vizierdb/api/CancelWorkflow.scala
+++ b/src/main/scala/info/vizierdb/api/CancelWorkflow.scala
@@ -41,13 +41,13 @@ object CancelWorkflowHandler
       DB.readOnly { implicit s => 
         workflowId match { 
           case None => 
-            Branch.lookup(projectId, branchId)
+            Branch.getOption(projectId, branchId)
                   .getOrElse {
                      return NoSuchEntityResponse()
                   }
                   .head
           case Some(id) =>
-            Workflow.lookup(projectId, branchId, id)
+            Workflow.getOption(projectId, branchId, id)
                     .getOrElse {
                        return NoSuchEntityResponse()
                     }

--- a/src/main/scala/info/vizierdb/api/CreateBranch.scala
+++ b/src/main/scala/info/vizierdb/api/CreateBranch.scala
@@ -51,7 +51,7 @@ case class CreateBranch(
                 .getOrElse { "Untitled Branch" }
     DB.autoCommit { implicit s => 
       val (project, branch, workflow): (Project, Branch, Workflow) = 
-        Project.lookup(projectId)
+        Project.getOption(projectId)
                .getOrElse { 
                  return NoSuchEntityResponse()
                }

--- a/src/main/scala/info/vizierdb/api/CreateDataset.scala
+++ b/src/main/scala/info/vizierdb/api/CreateDataset.scala
@@ -38,7 +38,7 @@ case class CreateDataset(
   {
     DB.autoCommit { implicit s => 
       val project = 
-        Project.lookup(projectId)
+        Project.getOption(projectId)
                .getOrElse { 
                   return NoSuchEntityResponse()
                }

--- a/src/main/scala/info/vizierdb/api/CreateFile.scala
+++ b/src/main/scala/info/vizierdb/api/CreateFile.scala
@@ -50,7 +50,7 @@ object CreateFileHandler
   ): Response = {
     DB.autoCommit { implicit s => 
       val project = 
-        Project.lookup(projectId)
+        Project.getOption(projectId)
                .getOrElse { 
                   return NoSuchEntityResponse()
                }

--- a/src/main/scala/info/vizierdb/api/DeleteBranch.scala
+++ b/src/main/scala/info/vizierdb/api/DeleteBranch.scala
@@ -32,7 +32,7 @@ object DeleteBranchHandler
     val branchId = pathParameters("branchId").as[Long]
     DB.readOnly { implicit s => 
       val p = 
-        Project.lookup(projectId)
+        Project.getOption(projectId)
                .getOrElse { 
                   return NoSuchEntityResponse()
                }
@@ -42,7 +42,7 @@ object DeleteBranchHandler
     }
     DB.autoCommit { implicit s => 
       val b = 
-        Branch.lookup(projectId = projectId, branchId = branchId)
+        Branch.getOption(projectId = projectId, branchId = branchId)
                .getOrElse { 
                   return NoSuchEntityResponse()
                }

--- a/src/main/scala/info/vizierdb/api/DeleteModule.scala
+++ b/src/main/scala/info/vizierdb/api/DeleteModule.scala
@@ -36,7 +36,7 @@ object DeleteModuleHandler
     val workflow = 
       DB.autoCommit { implicit s => 
         val branch = 
-          Branch.lookup(projectId = projectId, branchId = branchId)
+          Branch.getOption(projectId = projectId, branchId = branchId)
                  .getOrElse { 
                     return NoSuchEntityResponse()
                  }

--- a/src/main/scala/info/vizierdb/api/DeleteProject.scala
+++ b/src/main/scala/info/vizierdb/api/DeleteProject.scala
@@ -30,7 +30,7 @@ object DeleteProjectHandler extends SimpleHandler
     val projectId = pathParameters("projectId").as[Long]
     DB.autoCommit { implicit s => 
       val p = 
-        Project.lookup(projectId)
+        Project.getOption(projectId)
                .getOrElse { 
                   return NoSuchEntityResponse()
                }

--- a/src/main/scala/info/vizierdb/api/FreezeModules.scala
+++ b/src/main/scala/info/vizierdb/api/FreezeModules.scala
@@ -45,7 +45,7 @@ object FreezeModulesHandler
       DB.autoCommit { implicit s => 
         logger.trace(s"Looking up branch $branchId")
         val branch:Branch =
-          Branch.lookup(projectId, branchId)
+          Branch.getOption(projectId, branchId)
                 .getOrElse { 
                    return NoSuchEntityResponse()
                 }

--- a/src/main/scala/info/vizierdb/api/GetAllModules.scala
+++ b/src/main/scala/info/vizierdb/api/GetAllModules.scala
@@ -36,9 +36,9 @@ object GetAllModulesHandler
       val workflowMaybe: Option[Workflow] = 
         workflowId match {
           case Some(workflowIdActual) => 
-            Workflow.lookup(projectId, branchId, workflowIdActual)
+            Workflow.getOption(projectId, branchId, workflowIdActual)
           case None => 
-            Branch.lookup(projectId, projectId).map { _.head }
+            Branch.getOption(projectId, projectId).map { _.head }
         } 
       workflowMaybe match {
         case Some(workflow) => RawJsonResponse(

--- a/src/main/scala/info/vizierdb/api/GetArtifact.scala
+++ b/src/main/scala/info/vizierdb/api/GetArtifact.scala
@@ -33,7 +33,7 @@ object GetArtifactHandler
 {
   def getArtifact(projectId: Long, artifactId: Long, expecting: Option[ArtifactType.T]): Option[Artifact] = 
       DB.readOnly { implicit session => 
-        Artifact.lookup(artifactId, Some(projectId))
+        Artifact.getOption(artifactId, Some(projectId))
       }.filter { artifact => 
         expecting.isEmpty || expecting.get.equals(artifact.t)
       }

--- a/src/main/scala/info/vizierdb/api/GetBranch.scala
+++ b/src/main/scala/info/vizierdb/api/GetBranch.scala
@@ -32,7 +32,7 @@ object GetBranchHandler
     val projectId = pathParameters("projectId").as[Long]
     val branchId = pathParameters("branchId").as[Long]
     DB.readOnly { implicit session => 
-      Branch.lookup(projectId, branchId) match {
+      Branch.getOption(projectId, branchId) match {
         case Some(branch) => RawJsonResponse(branch.describe)
         case None => NoSuchEntityResponse()
       }

--- a/src/main/scala/info/vizierdb/api/GetModule.scala
+++ b/src/main/scala/info/vizierdb/api/GetModule.scala
@@ -38,9 +38,9 @@ object GetModuleHandler
       val workflowMaybe: Option[Workflow] = 
         workflowId match {
           case Some(workflowIdActual) => 
-            Workflow.lookup(projectId, branchId, workflowIdActual)
+            Workflow.getOption(projectId, branchId, workflowIdActual)
           case None => 
-            Branch.lookup(projectId, projectId).map { _.head }
+            Branch.getOption(projectId, projectId).map { _.head }
         } 
       val cellMaybe: Option[Cell] = 
         workflowMaybe.flatMap { _.cellByPosition(modulePosition) }

--- a/src/main/scala/info/vizierdb/api/GetProject.scala
+++ b/src/main/scala/info/vizierdb/api/GetProject.scala
@@ -31,7 +31,7 @@ object GetProjectHandler
   {
     val projectId = pathParameters("projectId").as[Long]
     DB.readOnly { implicit session => 
-      Project.lookup(projectId) match {
+      Project.getOption(projectId) match {
         case Some(project) => RawJsonResponse(project.describe)
         case None => NoSuchEntityResponse()
       }

--- a/src/main/scala/info/vizierdb/api/GetWorkflow.scala
+++ b/src/main/scala/info/vizierdb/api/GetWorkflow.scala
@@ -37,9 +37,9 @@ object GetWorkflowHandler
       val workflowMaybe: Option[Workflow] = 
         workflowId match {
           case Some(workflowIdActual) => 
-            Workflow.lookup(projectId, branchId, workflowIdActual)
+            Workflow.getOption(projectId, branchId, workflowIdActual)
           case None => 
-            Branch.lookup(projectId, branchId).map { _.head }
+            Branch.getOption(projectId, branchId).map { _.head }
         } 
       workflowMaybe match {
         case Some(workflow) => RawJsonResponse(Json.toJson(workflow.describe))

--- a/src/main/scala/info/vizierdb/api/ImportProject.scala
+++ b/src/main/scala/info/vizierdb/api/ImportProject.scala
@@ -65,7 +65,7 @@ object ImportProject
       }
 
     DB.readOnly { implicit session => 
-      Project.lookup(projectId) match {
+      Project.getOption(projectId) match {
         case Some(project) => RawJsonResponse(project.describe)
         case None => NoSuchEntityResponse()
       }

--- a/src/main/scala/info/vizierdb/api/InsertModule.scala
+++ b/src/main/scala/info/vizierdb/api/InsertModule.scala
@@ -44,7 +44,7 @@ case class InsertModule(
     val workflow: Workflow = 
       DB.autoCommit { implicit s => 
         val branch: (Branch) = 
-          Branch.lookup(projectId, branchId)
+          Branch.getOption(projectId, branchId)
                 .getOrElse { 
                   return NoSuchEntityResponse()
                 }

--- a/src/main/scala/info/vizierdb/api/ListBranches.scala
+++ b/src/main/scala/info/vizierdb/api/ListBranches.scala
@@ -31,7 +31,7 @@ object ListBranchesHandler
   {
     val projectId = pathParameters("projectId").as[Long]
     DB.readOnly { implicit session => 
-      Project.lookup(projectId)
+      Project.getOption(projectId)
         match { 
           case Some(project) => 
             RawJsonResponse(

--- a/src/main/scala/info/vizierdb/api/ReplaceModule.scala
+++ b/src/main/scala/info/vizierdb/api/ReplaceModule.scala
@@ -42,7 +42,7 @@ case class ReplaceModule(
     val workflow: Workflow = 
       DB.autoCommit { implicit s => 
         val branch: Branch = 
-          Branch.lookup(projectId, branchId)
+          Branch.getOption(projectId, branchId)
                  .getOrElse { 
                    return NoSuchEntityResponse()
                  }

--- a/src/main/scala/info/vizierdb/api/ThawModules.scala
+++ b/src/main/scala/info/vizierdb/api/ThawModules.scala
@@ -44,7 +44,7 @@ object ThawModulesHandler
       DB.autoCommit { implicit s => 
         logger.trace(s"Looking up branch $branchId")
         val branch:Branch =
-          Branch.lookup(projectId, branchId)
+          Branch.getOption(projectId, branchId)
                 .getOrElse { 
                    return NoSuchEntityResponse()
                 }

--- a/src/main/scala/info/vizierdb/api/UpdateBranch.scala
+++ b/src/main/scala/info/vizierdb/api/UpdateBranch.scala
@@ -35,7 +35,7 @@ case class UpdateBranch(
   {
     DB.autoCommit { implicit s => 
       val branch: Branch = 
-        Branch.lookup(projectId, branchId)
+        Branch.getOption(projectId, branchId)
                .getOrElse { 
                  return NoSuchEntityResponse()
                }

--- a/src/main/scala/info/vizierdb/api/UpdateProject.scala
+++ b/src/main/scala/info/vizierdb/api/UpdateProject.scala
@@ -35,7 +35,7 @@ case class UpdateProject(
   {
     val project: Project = 
       DB.autoCommit { implicit s => 
-        var project = Project.lookup(projectId)
+        var project = Project.getOption(projectId)
                              .getOrElse { 
                                return NoSuchEntityResponse()
                              }

--- a/src/main/scala/info/vizierdb/api/WorkflowSQL.scala
+++ b/src/main/scala/info/vizierdb/api/WorkflowSQL.scala
@@ -46,9 +46,9 @@ object WorkflowSQLHandler
         val workflow: Workflow = 
           (workflowId match {
             case Some(workflowIdActual) => 
-              Workflow.lookup(projectId, branchId, workflowIdActual)
+              Workflow.getOption(projectId, branchId, workflowIdActual)
             case None => 
-              Branch.lookup(projectId, branchId).map { _.head }
+              Branch.getOption(projectId, branchId).map { _.head }
           }).getOrElse {
             return NoSuchEntityResponse()
           }

--- a/src/main/scala/info/vizierdb/catalog/Artifact.scala
+++ b/src/main/scala/info/vizierdb/catalog/Artifact.scala
@@ -256,8 +256,8 @@ object Artifact
     Artifact.get(artifactId)
   }
 
-  def get(target: Identifier, projectId: Option[Identifier] = None)(implicit session:DBSession): Artifact = lookup(target, projectId).get
-  def lookup(target: Identifier, projectId: Option[Identifier] = None)(implicit session:DBSession): Option[Artifact] = 
+  def get(target: Identifier, projectId: Option[Identifier] = None)(implicit session:DBSession): Artifact = getOption(target, projectId).get
+  def getOption(target: Identifier, projectId: Option[Identifier] = None)(implicit session:DBSession): Option[Artifact] = 
     withSQL { 
       val b = Artifact.syntax 
       select

--- a/src/main/scala/info/vizierdb/catalog/Branch.scala
+++ b/src/main/scala/info/vizierdb/catalog/Branch.scala
@@ -22,11 +22,11 @@ import info.vizierdb.types._
 import java.time.format.DateTimeFormatter
 import info.vizierdb.util.HATEOAS
 import info.vizierdb.catalog.binders._
-import info.vizierdb.viztrails.Scheduler
 import info.vizierdb.VizierAPI
 import info.vizierdb.util.StupidReactJsonMap
-import info.vizierdb.viztrails.Provenance
+import info.vizierdb.viztrails.{ Scheduler, Provenance, StateTransition }
 import info.vizierdb.delta.DeltaBus
+import ExecutionState.{ WAITING, STALE, RUNNING, ERROR, CANCELLED, DONE, FROZEN }
 
 /**
  * One branch of the project
@@ -43,7 +43,58 @@ case class Branch(
   createdFromWorkflowId: Option[Identifier]
 )
 {
+  /**
+   * Retrieve the head [[Workflow]]
+   */
   def head(implicit session: DBSession): Workflow = Workflow.get(headId)
+
+  /**
+   * Update the branch head by creating a module and appending it to the workflow
+   * 
+   * @param packageId       The package id of the module's command
+   * @param commandId       The command id of the module's command
+   * @param args            The module's arguments
+   * @return                The updated Branch object and the new head [[Workflow]]
+   */
+  def append(packageId: String, commandId: String)
+            (args: (String, Any)*)
+            (implicit session: DBSession): (Branch, Workflow) =
+    append(Module.make(packageId, commandId)(args:_*))
+
+  /**
+   * Update the branch head by creating a module and inserting it into the workflow
+   * 
+   * @param position        The position of the newly inserted cell
+   * @param packageId       The package id of the module's command
+   * @param commandId       The command id of the module's command
+   * @param args            The module's arguments
+   * @return                The updated Branch object and the new head [[Workflow]]
+   */
+  def insert(position: Int, packageId: String, commandId: String)
+            (args: (String, Any)*)
+            (implicit session: DBSession): (Branch, Workflow) =
+    insert(position, Module.make(packageId, commandId)(args:_*))
+
+  /**
+   * Update the branch head by creating a module and replacing an existing cell with it
+   * 
+   * @param position        The position of the cell to modify
+   * @param packageId       The package id of the module's command
+   * @param commandId       The command id of the module's command
+   * @param args            The module's arguments
+   * @return                The updated Branch object and the new head [[Workflow]]
+   */
+  def update(position: Int, packageId: String, commandId: String)
+            (args: (String, Any)*)
+            (implicit session: DBSession): (Branch, Workflow) =
+    update(position, Module.make(packageId, commandId)(args:_*))
+
+  /**
+   * Update the branch head by appending a module to the workflow
+   * 
+   * @param module          The module to append
+   * @return                The updated Branch object and the new head [[Workflow]]
+   */
   def append(module: Module)(implicit session: DBSession): (Branch, Workflow) = 
   {
     val ret = modify(
@@ -55,10 +106,14 @@ case class Branch(
     DeltaBus.notifyCellAppend(ret._2)
     return ret
   }
-  def append(packageId: String, commandId: String)
-            (args: (String, Any)*)
-            (implicit session: DBSession): (Branch, Workflow) =
-    append(Module.make(packageId, commandId)(args:_*))
+
+  /**
+   * Update the branch head by inserting a module into the workflow
+   * 
+   * @param position        The position of the newly inserted cell
+   * @param module          The module to insert
+   * @return                The updated Branch object and the new head [[Workflow]]
+   */
   def insert(position: Int, module: Module)(implicit session: DBSession): (Branch, Workflow) =
   {
     val ret = modify(
@@ -66,13 +121,7 @@ case class Branch(
       action = ActionType.INSERT,
       prevWorkflowId = headId,
       updatePosition = sqls"case when position >= $position then position + 1 else position end",
-      updateState = sqls"""
-          case when state = ${ExecutionState.FROZEN.id} then ${ExecutionState.FROZEN.id} 
-               when position >= $position and state = ${ExecutionState.ERROR.id} then ${ExecutionState.STALE.id}
-               when position >= $position and state = ${ExecutionState.CANCELLED.id} then ${ExecutionState.STALE.id}
-               when position >= $position then ${ExecutionState.WAITING.id} 
-               else state end
-      """,
+      recomputeCellsFrom = position,
       addModules = Seq(module.id -> position)
     )
     DeltaBus.notifyCellInserts(ret._2){ (cell, _) => cell.position == position }
@@ -81,46 +130,21 @@ case class Branch(
     }
     return ret
   }
-  def delete(position: Int)(implicit session: DBSession): (Branch, Workflow) =
-  {
-    val ret = modify(
-      module = None,
-      action = ActionType.DELETE,
-      prevWorkflowId = headId,
-      updatePosition = sqls"case when position > $position then position - 1 else position end",
-      updateState = sqls"""
-          case when state = ${ExecutionState.FROZEN.id} then ${ExecutionState.FROZEN.id} 
-               when position >= $position and state = ${ExecutionState.ERROR.id} then ${ExecutionState.STALE.id}
-               when position >= $position and state = ${ExecutionState.CANCELLED.id} then ${ExecutionState.STALE.id}
-               when position >= $position then ${ExecutionState.WAITING.id} 
-               else state end
-      """,
-      keepCells = sqls"position <> $position",
-      forceRecomputeState = true
-    )
-    DeltaBus.notifyCellDelete(ret._2, position)
-    for(cell <- ret._2.cellsWhere(sqls"position >= ${position}")){
-      DeltaBus.notifyStateChange(ret._2, cell.position, cell.state)
-    }
-    return ret
-  }
-  def insert(position: Int, packageId: String, commandId: String)
-            (args: (String, Any)*)
-            (implicit session: DBSession): (Branch, Workflow) =
-    insert(position, Module.make(packageId, commandId)(args:_*))
+
+  /**
+   * Update the branch head by replacing a cell in the workflow with a new module
+   * 
+   * @param position        The position of the cell to replace
+   * @param module          The module to replace the cell with
+   * @return                The updated Branch object and the new head [[Workflow]]
+   */
   def update(position: Int, module: Module)(implicit session: DBSession): (Branch, Workflow) = 
   {
     val ret = modify(
       module = Some(module),
       action = ActionType.INSERT,
       prevWorkflowId = headId,
-      updateState = sqls"""
-          case when state = ${ExecutionState.FROZEN.id} then ${ExecutionState.FROZEN.id}
-               when position >= $position and state = ${ExecutionState.ERROR.id} then ${ExecutionState.STALE.id}
-               when position >= $position and state = ${ExecutionState.CANCELLED.id} then ${ExecutionState.STALE.id}
-               when position >= $position then ${ExecutionState.WAITING.id} 
-               else state end
-      """,
+      recomputeCellsFrom = position,
       keepCells = sqls"position <> $position",
       addModules = Seq(module.id -> position)
     )
@@ -130,50 +154,88 @@ case class Branch(
     }
     return ret
   }
-  def update(position: Int, packageId: String, commandId: String)
-            (args: (String, Any)*)
-            (implicit session: DBSession): (Branch, Workflow) =
-    update(position, Module.make(packageId, commandId)(args:_*))
+
+  /**
+   * Update the branch head by deleting a cell from the workflow
+   * 
+   * @param position        The position of the cell to delete
+   * @return                The updated Branch object and the new head [[Workflow]]
+   */
+  def delete(position: Int)(implicit session: DBSession): (Branch, Workflow) =
+  {
+    val ret = modify(
+      module = None,
+      action = ActionType.DELETE,
+      prevWorkflowId = headId,
+      updatePosition = sqls"case when position > $position then position - 1 else position end",
+      recomputeCellsFrom = position,
+      keepCells = sqls"position <> $position"
+    )
+    DeltaBus.notifyCellDelete(ret._2, position)
+    for(cell <- ret._2.cellsWhere(sqls"position >= ${position}")){
+      DeltaBus.notifyStateChange(ret._2, cell.position, cell.state)
+    }
+    return ret
+  }
+
+  /**
+   * Update the branch head by freezing one cell in the workflow
+   * 
+   * @param position        The position of the cell to freeze
+   * @return                The updated Branch object and the new head [[Workflow]]
+   * 
+   * A frozen cell is temporarily removed from the workflow.  Its result persists
+   * and is visible, but the cell itself is never scheduled for reexecution, and 
+   * its outputs are not visible to subsequent cells.
+   */
   def freezeOne(position: Int)(implicit session: DBSession): (Branch, Workflow) =
   {
     val ret = modify(
       module = None,
       action = ActionType.DELETE,
       prevWorkflowId = headId,
-      updateState = sqls"""
-        case when state = ${ExecutionState.FROZEN.id} then ${ExecutionState.FROZEN.id}
-             when position = $position then ${ExecutionState.FROZEN.id}
-             when position > $position and state = ${ExecutionState.ERROR.id} then ${ExecutionState.STALE.id}
-             when position > $position and state = ${ExecutionState.CANCELLED.id} then ${ExecutionState.STALE.id}
-             when position > $position then ${ExecutionState.WAITING.id}
-             else state end
-      """
+      updateState = 
+        StateTransition.forAll(sqls"position = $position" , FROZEN),
+      recomputeCellsFrom = position+1
     )
     for(cell <- ret._2.cellsWhere(sqls"position >= ${position}")){
       DeltaBus.notifyStateChange(ret._2, cell.position, cell.state)
     }
     return ret
   }
+
+  /**
+   * Update the branch head by thawing one cell in the workflow
+   * 
+   * @param position        The position of the cell to thaw
+   * @return                The updated Branch object and the new head [[Workflow]]
+   */
   def thawOne(position: Int)(implicit session: DBSession): (Branch, Workflow) =
   {
     val ret = modify(
       module = None,
       action = ActionType.DELETE,
       prevWorkflowId = headId,
-      updateState = sqls"""
-        case when position = $position then ${ExecutionState.STALE.id}
-             when state = ${ExecutionState.FROZEN.id} then ${ExecutionState.FROZEN.id}
-             when position > $position and state = ${ExecutionState.ERROR.id} then ${ExecutionState.STALE.id}
-             when position > $position and state = ${ExecutionState.CANCELLED.id} then ${ExecutionState.STALE.id}
-             when position > $position then ${ExecutionState.WAITING.id}
-             else state end
-      """
+      updateState = 
+        StateTransition( sqls"position = $position", FROZEN -> WAITING ),
+      recomputeCellsFrom = position+1
     )
     for(cell <- ret._2.cellsWhere(sqls"position >= ${position}")){
       DeltaBus.notifyStateChange(ret._2, cell.position, cell.state)
     }
     return ret
   }
+
+  /**
+   * Update the branch head by freezing cells in workflow starting from a position
+   * 
+   * @param position        The position of the first cell to freeze
+   * @return                The updated Branch object and the new head [[Workflow]]
+   * 
+   * A frozen cell is temporarily removed from the workflow.  Its result persists
+   * and is visible, but the cell itself is never scheduled for reexecution, and 
+   * its outputs are not visible to subsequent cells.
+   */
   def freezeFrom(position: Int)
                 (implicit session: DBSession): (Branch, Workflow) =
   {
@@ -181,16 +243,21 @@ case class Branch(
       module = None,
       action = ActionType.FREEZE,
       prevWorkflowId = headId,
-      updateState = sqls"""
-          case when position >= $position then ${ExecutionState.FROZEN.id}
-               else state end
-      """
+      updateState = 
+        StateTransition.forAll(sqls"position >= $position", FROZEN)
     )
     for(cell <- ret._2.cellsWhere(sqls"position >= ${position}")){
       DeltaBus.notifyStateChange(ret._2, cell.position, cell.state)
     }
     return ret
   }
+
+  /**
+   * Update the branch head by thawing cells in the workflow prior to a position
+   * 
+   * @param position        The position of the last cell to thaw
+   * @return                The updated Branch object and the new head [[Workflow]]
+   */
   def thawUpto(position: Int)
               (implicit session: DBSession): (Branch, Workflow) =
   {
@@ -198,13 +265,9 @@ case class Branch(
       module = None,
       action = ActionType.FREEZE,
       prevWorkflowId = headId,
-      updateState = sqls"""
-          case when position <= $position 
-                      and state = ${ExecutionState.FROZEN.id}
-                    then ${ExecutionState.WAITING.id}
-               else state end
-      """,
-      forceRecomputeState = true,
+      updateState = 
+        StateTransition(sqls"position <= $position", FROZEN -> WAITING),
+      recomputeCellsFrom = position + 1
     )
     for(cell <- ret._2.cellsWhere(sqls"position <= ${position}")){
       DeltaBus.notifyStateChange(ret._2, cell.position, cell.state)
@@ -212,6 +275,9 @@ case class Branch(
     return ret
   }
 
+  /**
+   * Create a barebones, empty workflow
+   */
   private[vizierdb] def initWorkflow(
     prevId: Option[Identifier] = None,
     action: ActionType.T = ActionType.CREATE,
@@ -242,15 +308,47 @@ case class Branch(
     }
   }
 
+  val DEFAULT_STATE_TRANSITIONS = 
+    StateTransition(RUNNING -> STALE) ++
+    StateTransition(ERROR -> STALE) ++
+    StateTransition(CANCELLED -> WAITING)
+
+  /**
+   * Utility method to create a workflow derived from the current branch head
+   * 
+   * @param module             The module involved in the action
+   * @param action             The action type
+   * @param prevWorkflowId     The workflowId of the prior workflow (defaults to the branch head)
+   * @param updatePosition     A [[SQLSyntax]] defining the position of cells in the new workflow 
+   *                           (defaults to the identity function)
+   * @param updateState        A [[Seq]] of [[StateTransitions]] describing how cell states should
+   *                           be revised in the derived workflow.  By default, the state 
+   *                           transitions in [[Branch.DEFAULT_STATE_TRANSITIONS]] will be used
+   *                           with a final fallback of the identity function.  
+   *                           [[StateTransition]]s provided here supersede this default behavior.
+   *                           also see the recomputeCellsFrom parameter.
+   * @param recomputeCellsFrom If provided, cells at or after the position specified in this 
+   *                           parameter will be scheduled for potential re-exeution.
+   * @param keepCells          A [[SQLSyntax]] with a boolean-valued expression.  Cells in the
+   *                           <b>original</b> workflow for which this expression evaluates to
+   *                           false will be dropped from the derived one.
+   * @param addModules         A set of module identifiers to add as new cells, provided as 
+   *                           <tt>(moduleId -> position)</tt> pairs.
+   * @return                   The updated Branch object and the new head [[Workflow]]
+   * 
+   * Note that all [[SQLSyntax]] expressions (updatePosition, updateState, keepCells) are 
+   * evaluated on the cells of the <b>original</b> workflow.  Positions are thus the positions 
+   * from the original workflow.
+   */
   private def modify(
     module: Option[Module],
     action: ActionType.T,
     prevWorkflowId: Identifier = headId,
     updatePosition: SQLSyntax = sqls"position",
-    updateState: SQLSyntax = sqls"state",
+    updateState: Seq[StateTransition] = Seq.empty,
+    recomputeCellsFrom: Int = -1,
     keepCells: SQLSyntax = sqls"1=1",
-    addModules: Iterable[(Identifier, Int)] = Seq(),
-    forceRecomputeState: Boolean = false
+    addModules: Iterable[(Identifier, Int)] = Seq()
   )(implicit session: DBSession): (Branch, Workflow) = 
   {
     // Note: we're working with immutable objects here.  `branch` will be the 
@@ -261,6 +359,13 @@ case class Branch(
       actionModuleId = module.map { _.id }
     )
 
+    val stateTransitions = 
+      updateState ++ (
+        if(recomputeCellsFrom >= 0){
+          StateTransition( sqls"position >= $recomputeCellsFrom", DONE -> WAITING)
+        } else { Seq.empty }
+      ) ++ DEFAULT_STATE_TRANSITIONS
+
     withSQL {
       val c = Cell.syntax
       insertInto(Cell)
@@ -268,8 +373,8 @@ case class Branch(
           sqls"""${workflow.id} as workflow_id""",
           updatePosition + sqls" as position",
           c.moduleId,
-          c.resultId,
-          updateState + sqls" as state",
+          StateTransition.updateResult(stateTransitions) + sqls" as resultId",
+          StateTransition.updateState(stateTransitions) + sqls" as state",
           c.created,
         ) {
           _.from(Cell as c)
@@ -286,19 +391,30 @@ case class Branch(
         created = ZonedDateTime.now()
       )
     }
-    if(forceRecomputeState){
-      Provenance.updateCellStates(workflow.cellsInOrder, Map.empty)
-    }
+    Provenance.updateCellStates(workflow.cellsInOrder, Map.empty)
 
     return (branch, workflow)
   }
 
+  /**
+   * The id of the module used in the first branch operation that created this branch.
+   * 
+   * @return        The identifier of the Module or None if no module was used
+   */
   def createdFromModuleId(implicit session:DBSession): Option[Identifier] =
     createdFromWorkflowId.flatMap { Workflow.get(_).actionModuleId }
 
+  /**
+   * Initialize this branch by cloning an existing workflow.
+   * 
+   * @return                   The updated Branch object and the new head [[Workflow]]
+   */
   private[vizierdb] def cloneWorkflow(workflowId: Identifier)(implicit session: DBSession): (Branch, Workflow) =
     modify(None, ActionType.CREATE, workflowId)
 
+  /**
+   * Enumerate the [[Workflow]]s of this branch
+   */
   def workflows(implicit session:DBSession): Seq[Workflow] = 
     withSQL { 
       val w = Workflow.syntax 
@@ -307,9 +423,15 @@ case class Branch(
         .where.eq(w.branchId, id)  
     }.map { Workflow(_) }.list.apply()
 
+  /**
+   * Retrieve the [[Workflow]] used to create this branch.
+   */
   def createdFromWorkflow(implicit session:DBSession): Option[Workflow] = 
     createdFromWorkflowId.map { Workflow.get(_) }
 
+  /**
+   * Generate a Branch Description, suitable for sending to a Vizier frontend
+   */
   def describe(implicit session:DBSession): JsObject =
     JsObject(
       summarize.value ++ Map(
@@ -317,6 +439,11 @@ case class Branch(
       )
     )
 
+  /**
+   * Generate a Branch Summary, suitable for sending to a Vizier frontend 
+   * 
+   * A Workflow Branch is a simplified Branch Description (does not contain workflows)
+   */
   def summarize(implicit session:DBSession): JsObject = 
     Json.obj(
       "id"             -> JsString(id.toString),
@@ -334,6 +461,10 @@ case class Branch(
         HATEOAS.BRANCH_UPDATE  -> VizierAPI.urls.updateBranch(projectId, id),
       ),
     )
+
+  /**
+   * Delete this branch and all contained workflows.
+   */
   def deleteBranch(implicit session: DBSession)
   {
     for(workflow <- workflows){
@@ -346,6 +477,12 @@ case class Branch(
     }.update.apply()
   }
 
+  /**
+   * Update the properties field of this branch
+   * 
+   * @param name        The new name of this branch
+   * @param properties  A dictionary of properties to associate with this branch
+   */ 
   def updateProperties(
     name: String,
     properties: Map[String, JsValue]
@@ -369,8 +506,15 @@ object Branch
   def apply(rs: WrappedResultSet): Branch = autoConstruct(rs, (Branch.syntax).resultName)
   override def columns = Schema.columns(table)
 
-  def get(target: Identifier)(implicit session:DBSession): Branch = lookup(target).get
-  def lookup(target: Identifier)(implicit session:DBSession): Option[Branch] = 
+  /**
+   * Retrieve the specified Branch
+   */
+  def get(target: Identifier)(implicit session:DBSession): Branch = getOption(target).get
+
+  /**
+   * Retrieve the specified Branch, returning None if the branch does not exist.
+   */
+  def getOption(target: Identifier)(implicit session:DBSession): Option[Branch] = 
     withSQL { 
       val b = Branch.syntax 
       select
@@ -378,7 +522,18 @@ object Branch
         .where.eq(b.id, target) 
     }.map { apply(_) }.single.apply()
 
-  def lookup(projectId: Identifier, branchId: Identifier)(implicit session:DBSession): Option[Branch] = 
+  /**
+   * Retrieve the specified Branch, erroring if the branch does not exist or if it is
+   * not part of the specified [[Project]].
+   */
+  def get(projectId: Identifier, branchId: Identifier)(implicit session:DBSession): Branch = 
+    getOption(projectId, branchId).get
+
+  /**
+   * Retrieve the specified Branch, returning None if the branch does not exist or if it is
+   * not part of the specified [[Project]].
+   */
+  def getOption(projectId: Identifier, branchId: Identifier)(implicit session:DBSession): Option[Branch] = 
     withSQL { 
       val b = Branch.syntax 
       select

--- a/src/main/scala/info/vizierdb/catalog/Cell.scala
+++ b/src/main/scala/info/vizierdb/catalog/Cell.scala
@@ -23,50 +23,19 @@ import java.time.ZonedDateTime
 import info.vizierdb.VizierException
 
 /**
- * One cell in a workflow.  
+ * One cell in a [[Workflow]], assigning a computation described by a [[Module]] to
+ * a position in the workflow.
  * 
- * Broadly, a cell is a Many/Many relationship between Workflow and Module. Each cell is identified 
- * by its parent workflow and a unique, contiguous, zero-indexed position in that workflow.
+ * Broadly, a cell is a Many/Many relationship between [[Workflow]] and [[Module]]. 
+ * Each cell is identified by its parent workflow and a unique, contiguous, 
+ * zero-indexed position in that workflow.
  *
- * The cell is parameterized by a Module definition (referenced by moduleId), and may optionally
- * point to a Result (referenced by resultId).
+ * The cell is parameterized by a [[Module]] definition (referenced by moduleId), and  
+ * may optionally point to a [[Result]] (referenced by resultId).
  *
- * Cells are immutable once created, with the exception of the resultId and state fields.  Both
- * of these fields are intended to conform to monotonicity guarantees.
- *
- * state adopts conforms the following state diagram
- * ```
- *
- * Clone/Thaw Cell                    Freeze Cell
- *          \                              |
- *           v                             V
- *     --- WAITING -------------> DONE     FROZEN
- *    /       |                    ^
- *   /        v                    |
- *   |     BLOCKED ---+----> ERROR |
- *   |        |      /         ^  /
- *    \       v     /          | /
- *     `--> STALE --> RUNNING -+-
- *            ^
- *           /
- *   New Cell
- * 
- * ```
- * The value of resultId depends on the current state.
- * - WAITING: resultId references the [[Result]] from the previous execution of this cell.  Note 
- *            that the corresponding result may or may not be valid.  If the cell transitions to 
- *            the DONE state without going through the BLOCKED or STALE states, resultId will remain
- *            unchanged.
- * - BLOCKED or STALE: resultId is invalid and should be ignored.
- * - RUNNING: resultId is valid, but may be incomplete
- * - ERROR: resultId is either None (a preceding cell triggered the error) or Some(result) with a
- *          result object describing the error
- * - DONE: resultId references the result of the execution
- * - FROZEN: resultId references the [[Result]] from the previous execution, and
- *           like the WAITING state may or may not be valid.  However, the user has
- *           requested that the cell not be re-executed.
- *
- * In summary resultId should usually be ignored in all states except ERROR and DONE.
+ * Cells are immutable once created, with the exception of the resultId and state 
+ * fields.  Both of these fields are intended to conform to monotonicity guarantees
+ * detailed <a href="https://github.com/VizierDB/vizier-scala/wiki/DevGuide-CellStates">here</a>
  */
 case class Cell(
   workflowId: Identifier,
@@ -186,8 +155,8 @@ object Cell
   def apply(rs: WrappedResultSet): Cell = autoConstruct(rs, (Cell.syntax).resultName)
   override def columns = Schema.columns(table)
 
-  def get(workflowId: Identifier, position: Int)(implicit session:DBSession): Cell = lookup(workflowId, position).get
-  def lookup(workflowId: Identifier, position: Int)(implicit session:DBSession): Option[Cell] = 
+  def get(workflowId: Identifier, position: Int)(implicit session:DBSession): Cell = getOption(workflowId, position).get
+  def getOption(workflowId: Identifier, position: Int)(implicit session:DBSession): Option[Cell] = 
     withSQL { 
       val c = Cell.syntax 
       select

--- a/src/main/scala/info/vizierdb/catalog/Metadata.scala
+++ b/src/main/scala/info/vizierdb/catalog/Metadata.scala
@@ -24,13 +24,13 @@ object Metadata extends SQLSyntaxSupport[Metadata]
   def apply(p: ResultName[Metadata])(rs: WrappedResultSet): Metadata = 
     new Metadata(rs.string(p.key), rs.string(p.value))
 
-  def lookup(key: String)(implicit session: DBSession): Option[String] =
+  def getOption(key: String)(implicit session: DBSession): Option[String] =
     sql"SELECT value FROM Metadata WHERE key = $key"
       .map { _.string(1) }
       .single()
       .apply()
 
-  def get(key: String)(implicit session: DBSession): String = lookup(key).get
+  def get(key: String)(implicit session: DBSession): String = getOption(key).get
 
   def put(key: String, value: String)(implicit session: DBSession) = 
     sql"INSERT OR REPLACE INTO Metadata(key, value) VALUES($key, $value)".execute.apply()

--- a/src/main/scala/info/vizierdb/catalog/Module.scala
+++ b/src/main/scala/info/vizierdb/catalog/Module.scala
@@ -221,8 +221,8 @@ object Module
   }
 
 
-  def get(target: Identifier)(implicit session:DBSession): Module = lookup(target).get
-  def lookup(target: Identifier)(implicit session:DBSession): Option[Module] = 
+  def get(target: Identifier)(implicit session:DBSession): Module = getOption(target).get
+  def getOption(target: Identifier)(implicit session:DBSession): Option[Module] = 
     withSQL { 
       val w = Module.syntax 
       select

--- a/src/main/scala/info/vizierdb/catalog/Project.scala
+++ b/src/main/scala/info/vizierdb/catalog/Project.scala
@@ -95,7 +95,7 @@ case class Project(
       if(isInitialBranch) { None }
       else { 
         Some(
-          fromBranch.map { Branch.lookup(id, _).get }
+          fromBranch.map { Branch.get(id, _) }
                     .getOrElse { activeBranch }
         )
       }
@@ -103,7 +103,7 @@ case class Project(
       if(isInitialBranch) { None }
       else {
         Some( 
-          fromWorkflow.map { Workflow.lookup(sourceBranch.get.id, _).get.id }
+          fromWorkflow.map { Workflow.getOption(sourceBranch.get.id, _).get.id }
                       .getOrElse { sourceBranch.get.headId }
         )
       }
@@ -244,8 +244,8 @@ object Project
     }
   }
 
-  def get(target: Identifier)(implicit session:DBSession): Project = lookup(target).get
-  def lookup(target: Identifier)(implicit session:DBSession): Option[Project] = 
+  def get(target: Identifier)(implicit session:DBSession): Project = getOption(target).get
+  def getOption(target: Identifier)(implicit session:DBSession): Option[Project] = 
     withSQL { 
       val p = Project.syntax 
       select

--- a/src/main/scala/info/vizierdb/catalog/Schema.scala
+++ b/src/main/scala/info/vizierdb/catalog/Schema.scala
@@ -28,7 +28,7 @@ object Schema
     if(DB.getTable("metadata").isEmpty){ return 0 }
     else { 
       DB.readOnly { implicit session => 
-        Metadata.lookup("schema") 
+        Metadata.getOption("schema") 
       }.map { _.toInt }.getOrElse { 0 } 
     }
   }

--- a/src/main/scala/info/vizierdb/commands/plot/SimpleChart.scala
+++ b/src/main/scala/info/vizierdb/commands/plot/SimpleChart.scala
@@ -49,7 +49,9 @@ object SimpleChart extends Command
         "Line Chart with Points"   -> "Line Chart with Points",
         "Line Chart without Points"   -> "Line Chart without Points",
         "Scatter Plot" -> "Scatter Plot"
-      ), default = Some(1)),
+      ), default = Some(1), aliases = Map(
+        "Line Chart" -> "Line Chart with Points"
+      )),
       BooleanParameter(id = "chartGrouped", name = "Grouped", required = false, default = Some(true)),
     ))
   )

--- a/src/main/scala/info/vizierdb/commands/python/SparkPythonUDFRelay.scala
+++ b/src/main/scala/info/vizierdb/commands/python/SparkPythonUDFRelay.scala
@@ -34,7 +34,7 @@ object SparkPythonUDFRelay
   override def getPickle(name: String): Option[Array[Byte]] =
   {
     DB.readOnly { implicit s => 
-      Artifact.lookup(name.toLong) 
+      Artifact.getOption(name.toLong) 
     }.map { artifact: Artifact => 
       if( (artifact.t != ArtifactType.FUNCTION)
           || (artifact.mimeType != MIME.PYTHON))

--- a/src/main/scala/info/vizierdb/export/ExportProject.scala
+++ b/src/main/scala/info/vizierdb/export/ExportProject.scala
@@ -57,7 +57,7 @@ object ExportProject
     // File Artifacts
     DB.readOnly { implicit s => 
       val p = 
-        Project.lookup(projectId)
+        Project.getOption(projectId)
                .getOrElse { 
                  throw new VizierException(s"No project with ID $projectId")
                }

--- a/src/main/scala/info/vizierdb/types.scala
+++ b/src/main/scala/info/vizierdb/types.scala
@@ -58,8 +58,8 @@ object types
                                             error */
     val WAITING   = Value(3, "WAITING")  /* The referenced execution follows a stale cell and *may* be 
                                             out-of-date, depending on the outcome of the stale cell  */
-    val BLOCKED   = Value(4, "BLOCKED")  /* The referenced execution is incorrect for this workflow and 
-                                            needs to be recomputed, but is blocked on another one */
+    // There existed a BLOCKED state (id=4) during development that was never
+    // actually used.
     val STALE     = Value(5, "STALE")    /* The referenced execution is incorrect for this workflow and 
                                             needs to be recomputed */
     val CANCELLED = Value(6, "CANCELLED")/* Execution of the cell or a cell preceding it was 
@@ -74,7 +74,6 @@ object types
         case DONE => 4      // MODULE_SUCCESS
         case ERROR => 3     // MODULE_ERROR
         case WAITING => 0   // MODULE_PENDING
-        case BLOCKED => 0   // MODULE_PENDING
         case STALE => 1     // MODULE_RUNNING
         case RUNNING => 1   // MODULE_RUNNING
         case CANCELLED => 2 // MODULE_CANCELLED
@@ -82,19 +81,22 @@ object types
       }
     }
 
-    def isRunningOrPendingState(state: T) = 
-    {
-      state match { 
-        case DONE => false
-        case ERROR => false
-        case WAITING => true
-        case BLOCKED => true
-        case STALE => true
-        case RUNNING => true
-        case CANCELLED => false
-        case FROZEN => false
-      }
-    }
+    val PENDING_STATES = Set(
+      WAITING,
+      STALE,
+      RUNNING,
+    )
+
+    val PROVENANCE_VALID_STATES = Set(
+      DONE,
+      WAITING,
+      STALE,
+      CANCELLED,
+      FROZEN
+    )
+    val PROVENANCE_NOT_VALID_STATES = 
+      this.values.toSet - PROVENANCE_VALID_STATES
+
     implicit val format = Format[T](
       new Reads[T]{
         def reads(j: JsValue): JsResult[T] = 

--- a/src/main/scala/info/vizierdb/types.scala
+++ b/src/main/scala/info/vizierdb/types.scala
@@ -81,21 +81,21 @@ object types
       }
     }
 
-    val PENDING_STATES = Set(
+    val PENDING_STATES: Set[T] = Set(
       WAITING,
       STALE,
       RUNNING,
     )
 
-    val PROVENANCE_VALID_STATES = Set(
+    val PROVENANCE_VALID_STATES: Set[T] = Set(
       DONE,
       WAITING,
       STALE,
       CANCELLED,
       FROZEN
     )
-    val PROVENANCE_NOT_VALID_STATES = 
-      this.values.toSet - PROVENANCE_VALID_STATES
+    val PROVENANCE_NOT_VALID_STATES: Set[T] = 
+      this.values.toSet -- PROVENANCE_VALID_STATES
 
     implicit val format = Format[T](
       new Reads[T]{

--- a/src/main/scala/info/vizierdb/viztrails/MutableProject.scala
+++ b/src/main/scala/info/vizierdb/viztrails/MutableProject.scala
@@ -43,10 +43,39 @@ class MutableProject(
   var projectId: Identifier
 )
 {
+  /**
+   * The current version of the [[Project]] represented by this mutable project
+   */
   def project: Project = DB readOnly { implicit s => Project.get(projectId) }
+
+  /**
+   * The current version of the active [[Branch]] being operated on by this mutable project
+   */
   def branch: Branch = DB readOnly { implicit s => Project.activeBranchFor(projectId) }
+
+  /**
+   * The head [[Workflow]] being operated on by this mutable project
+   */
   def head: Workflow = DB readOnly { implicit s => Project.activeHeadFor(projectId) }
 
+  /**
+   * Append a new command to the end of the workflow.  The existing workflow will be aborted
+   * (if running) and the new workflow will be executed asynchronously.
+   * 
+   * @param    packageId      The packageId of the command to add
+   * @param    commandId      The commandId of the command to add
+   * @param    args           A list of argument name -> value pairs in Scala-native format
+   * @return                  A 2-tuple of the Branch and Workflow created by the update
+   * 
+   * Example:
+   * <pre>
+   * project.append("vizual", "insertColumn")(
+   *    dataset -> "my_dataset"
+   *    name -> "My Column",
+   *    dataType -> "int"
+   * )
+   * </pre>
+   */
   def append(packageId: String, commandId: String)
             (args: (String, Any)*): (Branch, Workflow) =
   {
@@ -58,6 +87,26 @@ class MutableProject(
     Scheduler.schedule(ret._2.id)
     return ret
   }
+
+  /**
+   * Insert a new command somewhere into the workflow.  The existing workflow will be aborted
+   * (if running) and the new workflow will be executed asynchronously.
+   * 
+   * @param    position       The 0-numbered position where the inserted cell should be
+   * @param    packageId      The packageId of the command to add
+   * @param    commandId      The commandId of the command to add
+   * @param    args           A list of argument name -> value pairs in Scala-native format
+   * @return                  A 2-tuple of the Branch and Workflow created by the update
+   * 
+   * Example:
+   * <pre>
+   * project.insert(23, "vizual", "insertColumn")(
+   *    dataset -> "my_dataset"
+   *    name -> "My Column",
+   *    dataType -> "int"
+   * )
+   * </pre>
+   */
   def insert(position: Int, packageId: String, commandId: String)
             (args: (String, Any)*): (Branch, Workflow) =
   {
@@ -69,6 +118,26 @@ class MutableProject(
     Scheduler.schedule(ret._2.id)
     return ret
   }
+
+  /**
+   * Replace an existing cell in the workflow with a new command.  The existing workflow will be 
+   * aborted (if running) and the new workflow will be executed asynchronously.
+   * 
+   * @param    position       The 0-numbered position of the cell to replace
+   * @param    packageId      The packageId of the command to add
+   * @param    commandId      The commandId of the command to add
+   * @param    args           A list of argument name -> value pairs in Scala-native format
+   * @return                  A 2-tuple of the Branch and Workflow created by the update
+   * 
+   * Example:
+   * <pre>
+   * project.update(23, "vizual", "insertColumn")(
+   *    dataset -> "my_dataset"
+   *    name -> "My Column",
+   *    dataType -> "int"
+   * )
+   * </pre>
+   */
   def update(position: Int, packageId: String, commandId: String)
             (args: (String, Any)*): (Branch, Workflow) =
   {
@@ -80,6 +149,14 @@ class MutableProject(
     Scheduler.schedule(ret._2.id)
     return ret
   }
+
+  /**
+   * Freeze all cells starting from a given position.  The existing workflow will be aborted
+   * (if running) and the new workflow will be executed asynchronously (typically a no-op).
+   * 
+   * @param    position       The 0-numbered position of the first cell to freeze
+   * @return                  A 2-tuple of the Branch and Workflow created by the update
+   */
   def freezeFrom(position: Int): (Branch, Workflow) =
   {
     val (oldbranch, ret) = DB autoCommit { implicit s => 
@@ -90,6 +167,14 @@ class MutableProject(
     Scheduler.schedule(ret._2.id)
     return ret
   }
+
+  /**
+   * Thaw all cells up to and including a given position.  The existing workflow will be aborted
+   * (if running) and the new workflow will be executed asynchronously.
+   * 
+   * @param    position       The 0-numbered position of the last cell to thaw
+   * @return                  A 2-tuple of the Branch and Workflow created by the update
+   */
   def thawUpto(position: Int): (Branch, Workflow) =
   {
     val (oldbranch, ret) = DB autoCommit { implicit s => 
@@ -101,11 +186,18 @@ class MutableProject(
     return ret
   }
 
+  /**
+   * Block the calling thread until the current head workflow has completed execution.
+   */
   def waitUntilReady
   {
     Scheduler.joinWorkflow(head.id, failIfNotRunning = false)
   }
 
+  /**
+   * Block the calling thread until the current head workflow has completed execution, and throw
+   * an exception if the workflow execution encountered an error.
+   */
   def waitUntilReadyAndThrowOnError
   {
     waitUntilReady
@@ -124,6 +216,12 @@ class MutableProject(
     }
   }
 
+  /**
+   * Retrieve the messages produced by the cell at a specified position
+   * @param   idx        The position of a cell
+   * @return             A sequence of [[Message]]s produced by the cell at this position or 
+   *                     None if there is no cell at this position
+   */
   def apply(idx: Int): Option[Seq[Message]] =
   {
     DB.readOnly { implicit s => 
@@ -133,6 +231,17 @@ class MutableProject(
     }
   }
 
+  /**
+   * Load a dataset into this mutable project (shorthand for <tt>append("data", "load")(_)</tt>)
+   * @param file           The file to load (ok to use relative file paths)
+   * @param name           The name of the dataset to create
+   * @param format         The file format (default: "csv"); See [[LoadDataset]]
+   * @param inferTypes     If true, the loading process will attempt to guess the type for all
+   *                       string columns loaded by spark.  (default: true)
+   * @param schema         Override the schema inferred by the data loader (default: use the 
+   *                       data loader's schema)
+   * @param waitForResult  If true, the load is processed synchronously (default: true)
+   */
   def load(
     file: String, 
     name: String, 
@@ -155,81 +264,14 @@ class MutableProject(
     )
     if(waitForResult) { waitUntilReadyAndThrowOnError }
   }
-
-  def script(
-    script: String, 
-    language: String = "python", 
-    waitForResult: Boolean = true
-  ) = 
-  {
-    append("script", language)("source" -> script)
-    if(waitForResult) { waitUntilReadyAndThrowOnError }
-  }
-
-  def vizual(dataset: String, script: VizualCommand*) =
-  {
-    append("vizual", "script")(
-      "dataset" -> dataset,
-      "script" -> VizualScript.encode(script)
-    )
-    waitUntilReadyAndThrowOnError
-  }
-  def sql(script: String): Unit = sql(script -> null)
-  def sql(scriptTarget: (String, String)): Unit =
-  {
-    append("sql", "query")(
-      "source" -> scriptTarget._1,
-      "output_dataset" -> Option(scriptTarget._2)
-    )
-    waitUntilReadyAndThrowOnError
-  }
-  def setParameters(params: (String, Any)*)
-  {
-    append("data", "parameters")(
-      DeclareParameters.PARAM_LIST -> 
-        params.map { case (k, v) => 
-          val (t, s) = v match {
-            case s: String     => StringType -> s
-            case i: Integer    => IntegerType -> i.toString
-            case f: Float      => FloatType -> f.toString
-            case d: Double     => DoubleType -> d.toString
-          }
-          Map(
-            DeclareParameters.PARAM_NAME -> k,
-            DeclareParameters.PARAM_VALUE -> s,
-            DeclareParameters.PARAM_TYPE -> SparkSchema.encodeType(t)
-          )
-        }
-    )
-  }
-
-
-  def lastOutput =
-  {
-    val workflow = head
-    DB.readOnly { implicit s => 
-      workflow.cells.reverse.head.messages
-    }
-  }
-  def lastOutputString =
-    lastOutput.map { _.dataString }.mkString("\n")
-
-  def artifactRefs: Seq[ArtifactRef] = 
-  {
-    val workflow = head
-    DB.readOnly { implicit s => 
-      workflow.outputArtifacts
-    }
-  }
-
-  def artifacts: Seq[Artifact] =
-  {
-    val refs = artifactRefs
-    DB.readOnly { implicit s => 
-      refs.map { _.get.get }
-    }    
-  }
-
+  
+  /**
+   * Import a file into this mutable project
+   * @param file           The file to import (ok to use relative file paths)
+   * @param name           The name of the dataset to create (default: use the filename)
+   * @param mimetype       The MIME type of the file
+   * @return               The [[Artifact]] of the imported file.
+   */
   def addFile(
     file: File, 
     name: Option[String] = None,
@@ -257,6 +299,139 @@ class MutableProject(
     return artifact
   }
 
+  /**
+   * Execute a script (shorthand for <tt>append("script", _)(_)</tt>)
+   * @param script         The text of the script
+   * @param language       The scripting language to use (default: python)
+   * @param waitForResult  If true, the script is evaluated synchronously (default: true)
+   */
+  def script(
+    script: String, 
+    language: String = "python", 
+    waitForResult: Boolean = true
+  ) = 
+  {
+    append("script", language)("source" -> script)
+    if(waitForResult) { waitUntilReadyAndThrowOnError }
+  }
+
+  /**
+   * Execute a vizual script (shorthand for <tt>append("vizual", "script")(_)</tt>)
+   * @param dataset        The dataset to transform
+   * @param script         One or more vizual commands
+   * 
+   * The vizual script is evaluated synchronously.
+   */
+  def vizual(dataset: String, script: VizualCommand*) =
+  {
+    append("vizual", "script")(
+      "dataset" -> dataset,
+      "script" -> VizualScript.encode(script)
+    )
+    waitUntilReadyAndThrowOnError
+  }
+
+  /**
+   * Execute a sql query (shorthand for <tt>append("sql", "query")(_)</tt>)
+   * @param script         The text of the SQL query
+   * 
+   * The sql query is evaluated synchronously.
+   */
+  def sql(script: String): Unit = sql(script -> null)
+
+  /**
+   * Execute a sql query (shorthand for <tt>append("sql", "query")(_)</tt>)
+   * @param scriptTarget   A pair query -> target table
+   * 
+   * Example
+   * <pre>
+   * project.sql("SELECT * FROM R" -> "my_result")
+   * </pre>
+   * 
+   * The sql query is evaluated synchronously.
+   */
+  def sql(scriptTarget: (String, String)): Unit =
+  {
+    append("sql", "query")(
+      "source" -> scriptTarget._1,
+      "output_dataset" -> Option(scriptTarget._2)
+    )
+    waitUntilReadyAndThrowOnError
+  }
+
+  /**
+   * Set one or more parameter artifacts (shorthand for <tt>append("data", "parameters")(_)</tt>)
+   * @param params         One or more parameter -> value pairs (in scala native formats)
+   * 
+   * The parameter update cell is evaluated synchronously.
+   */
+  def setParameters(params: (String, Any)*)
+  {
+    append("data", "parameters")(
+      DeclareParameters.PARAM_LIST -> 
+        params.map { case (k, v) => 
+          val (t, s) = v match {
+            case s: String     => StringType -> s
+            case i: Integer    => IntegerType -> i.toString
+            case f: Float      => FloatType -> f.toString
+            case d: Double     => DoubleType -> d.toString
+          }
+          Map(
+            DeclareParameters.PARAM_NAME -> k,
+            DeclareParameters.PARAM_VALUE -> s,
+            DeclareParameters.PARAM_TYPE -> SparkSchema.encodeType(t)
+          )
+        }
+    )
+    waitUntilReadyAndThrowOnError
+  }
+
+  /**
+   * Retrieve the messages produced by the last cell in the workflow as a sequence of [[Message]]s
+   */
+  def lastOutput =
+  {
+    val workflow = head
+    DB.readOnly { implicit s => 
+      workflow.cells.reverse.head.messages
+    }
+  }
+
+  /**
+   * Retrieve the messages produced by the last cell in the workflow as a string
+   */
+  def lastOutputString =
+    lastOutput.map { _.dataString }.mkString("\n")
+
+  /**
+   * Retrieve [[ArtifactRef]]erences to all artifacts output by the entire workflow (the scope)
+   * @return              A collection of [[ArtifactRef]]s in the final cell's output scope.
+   */
+  def artifactRefs: Seq[ArtifactRef] = 
+  {
+    val workflow = head
+    DB.readOnly { implicit s => 
+      workflow.outputArtifacts
+    }
+  }
+
+  /**
+   * Retrieve all [[Artifact]]s output by the entire workflow (the scope)
+   * @return              A collection of [[Artifact]]s in the final cell's output scope.
+   */
+  def artifacts: Seq[Artifact] =
+  {
+    val refs = artifactRefs
+    DB.readOnly { implicit s => 
+      refs.map { _.get.get }
+    }    
+  }
+
+  /**
+   * Retrieve a specific [[Artifact]] in the output of the workflow
+   * @param artifactName  The name of an artifact output by the workflow
+   * @return              The [[Artifact]] identified by artifactName in the workflow's output
+   */
   def artifact(artifactName: String): Artifact = 
   {
     val ref = (
@@ -267,6 +442,15 @@ class MutableProject(
     )
     return DB.readOnly { implicit s => ref.get.get }
   }
+
+  /**
+   * Print a specific [[Artifact]] to the console to standard out
+   * 
+   * @param artifactName  The name of an artifact output by the workflow
+   * @param rows          The number of rows to output if the artifact is a dataset
+   * 
+   * This function returns nothing... it just prints.
+   */
   def show(artifactName: String, rows: Integer = null): Unit =
   {
 
@@ -283,6 +467,9 @@ class MutableProject(
     }
   }
 
+  /**
+   * Obtain a snapshot of the current workflow for use with [[ComputeDelta]]
+   */
   def snapshot: WorkflowState =
   {
     val b = branch
@@ -290,10 +477,26 @@ class MutableProject(
   }
 }
 
+/**
+ * Convenient wrapper class around the Project class that allows mutable access to the project and
+ * its dependencies.  Generally, this class should only be used for testing or interactive 
+ * exploration on the scala console.
+ */
 object MutableProject
 {
+  /**
+   * Create a brand new project and return a MutableProject for it
+   * @param name        The name to assign the new project
+   * @return            The constructed MutableProject
+   */
   def apply(name: String): MutableProject = 
     new MutableProject(DB.autoCommit { implicit s => Project.create(name).id })
+
+  /**
+   * Create a MutableProject for an existing project
+   * @param projectId   The project to wrap with this MutableProject
+   * @return            The constructed MutableProject
+   */
   def apply(projectId: Identifier): MutableProject = new MutableProject(projectId)
 }
 

--- a/src/main/scala/info/vizierdb/viztrails/Provenance.scala
+++ b/src/main/scala/info/vizierdb/viztrails/Provenance.scala
@@ -95,7 +95,7 @@ object Provenance
   def cellNeedsANewResult(cell: Cell, scope: Map[String, Identifier])(implicit session: DBSession): Boolean =
   {
     if(ExecutionState.PROVENANCE_NOT_VALID_STATES(cell.state)){
-      logger.trace("Cell is in a provenance-not-valid state.  Forcing a conflict")
+      logger.trace(s"Cell is in a provenance-not-valid state (${cell.state}).  Forcing a conflict")
       return true
     } else if(cell.resultId.isEmpty){
       logger.trace("Cell has no result.  By default this is a conflict.")
@@ -153,13 +153,13 @@ object Provenance
           }
         }
         case ExecutionState.STALE | ExecutionState.ERROR => {
-          logger.debug(s"Already STALE (or ERROR)")
+          logger.debug(if(curr.state == ExecutionState.STALE){"Already STALE"} else {"ERROR -> STALE" })
           hitFirstPendingCell = true
         }
         case ExecutionState.RUNNING => {
           // It's possible we'll hit a RUNNING cell if we're appending a
           // cell to the workflow.
-          logger.debug("Hit a RUNNING cell")
+          logger.debug("Already RUNNING")
           hitFirstPendingCell = true
         }
         case ExecutionState.DONE => {

--- a/src/main/scala/info/vizierdb/viztrails/Provenance.scala
+++ b/src/main/scala/info/vizierdb/viztrails/Provenance.scala
@@ -130,10 +130,15 @@ object Provenance
     //       ... but let's get it correct first.
     var scope = outputsAtStart
     var hitFirstStaleCell = false
-    
+
     for(curr <- cells){
       logger.debug(s"Updating execution state for $curr; $scope")
       curr.state match {
+        case ExecutionState.RUNNING => {
+          // It's possible we'll hit a RUNNING cell if we're appending a
+          // cell to the workflow.
+          logger.debug("Hit a RUNNING cell")
+        }
         case ExecutionState.STALE => {
           logger.debug(s"Already STALE")
           hitFirstStaleCell = true

--- a/src/main/scala/info/vizierdb/viztrails/StateTransition.scala
+++ b/src/main/scala/info/vizierdb/viztrails/StateTransition.scala
@@ -1,0 +1,124 @@
+package info.vizierdb.viztrails
+
+import scalikejdbc._
+import info.vizierdb.types.ExecutionState
+
+class StateTransition(
+  fromState: ExecutionState.T,
+  toState: ExecutionState.T,
+  condition: Option[SQLSyntax] = None,
+)
+{
+  def matcherSyntax = 
+    condition match { 
+      case None    => sqls"state = ${fromState.id}"
+      case Some(c) => sqls"state = ${fromState.id} and $c"
+    }
+
+  def keepResult = 
+    (fromState, toState) match {
+      case (ExecutionState.RUNNING, ExecutionState.DONE) => true
+      case (f, t) if ExecutionState.PROVENANCE_NOT_VALID_STATES(f)
+                   && ExecutionState.PROVENANCE_VALID_STATES(t) => false
+      case _ => true
+    }
+
+  def stateUpdateSyntax:SQLSyntax = 
+    sqls"when $matcherSyntax then $toState"
+
+  def resultUpdateSyntax:SQLSyntax = 
+    sqls"when $matcherSyntax then ${if(keepResult){ sqls"state" } else { sqls"null" }}"
+}
+
+/**
+ * Utility methods for managing cell state transitions.
+ * 
+ * See https://github.com/VizierDB/vizier-scala/wiki/DevGuide-CellStates
+ */
+object StateTransition
+{
+  /**
+   * Declare a state transition: <pre>
+   * StateTransition( RUNNING -> CANCELLED )
+   * </pre>
+   */
+  def apply(fromTo: (ExecutionState.T, ExecutionState.T)): Seq[StateTransition] = 
+    Seq(new StateTransition(
+      fromState = fromTo._1, 
+      toState = fromTo._2
+    ))
+
+  /**
+   * Declare a state transition that applies only to specific cells: <pre>
+   * StateTransition( sql"position > $position", RUNNING -> CANCELLED )
+   * </pre>
+   */
+  def apply(condition: SQLSyntax, fromTo: (ExecutionState.T, ExecutionState.T)): Seq[StateTransition] = 
+    Seq(new StateTransition(
+      fromState = fromTo._1, 
+      toState = fromTo._2, 
+      condition = Some(condition)))
+
+  /**
+   * Declare state transitions that affect all cells with a given condition: <pre>
+   * StateTransition( sql"position > $position", WAITING )
+   * </pre>
+   */
+  def forAll(condition: SQLSyntax, to: ExecutionState.T): Seq[StateTransition] = 
+    forAll(condition, ExecutionState.values -> to)
+
+  /**
+   * Declare state transitions that affect all cells with a state in a given list and a given 
+   * condition: <pre>
+   * StateTransition( sql"position > $position", ExecutionState.PENDING_STATES -> STALE )
+   * </pre>
+   */
+  def forAll(condition: SQLSyntax, fromTo: (Iterable[ExecutionState.T], ExecutionState.T)): Seq[StateTransition] = 
+    fromTo._1.map { state => 
+      new StateTransition(
+        fromState = state, 
+        toState = fromTo._2, 
+        condition = Some(condition)) 
+    }.toSeq
+
+  /**
+   * Declare state transitions that affect all cells with a state in a given list: <pre>
+   * StateTransition( ExecutionState.PENDING_STATES -> CANCELLED )
+   * </pre>
+   */
+  def forAll(fromTo: (Iterable[ExecutionState.T], ExecutionState.T)): Seq[StateTransition] = 
+    fromTo._1.map { state => 
+      new StateTransition(
+        fromState = state, 
+        toState = fromTo._2) 
+    }.toSeq
+
+  /**
+   * Generate a [[SQLSyntax]] case statement that derives the new cell state given a set
+   * of declared state transitions.
+   */
+  def updateState(transitions: Seq[StateTransition]): SQLSyntax =
+    if(transitions.isEmpty){
+      sqls"state"
+    } else {
+      transitions.map { _.stateUpdateSyntax }
+                 .foldLeft(sqls"case") { _ + sqls" " + _ } + sqls" else state end"
+    }
+
+  /**
+   * Generate a [[SQLSyntax]] case statement that derives the new result reference
+   * of declared state transitions.
+   * 
+   * In particular, any state transition from a PROVENANCE_NOT_VALID state to a 
+   * PROVENANCE_VALID state must invalidate the resultId (see the discussion at:
+   * https://github.com/VizierDB/vizier-scala/wiki/DevGuide-CellStates#state-definitions)
+   */
+  def updateResult(transitions: Seq[StateTransition]): SQLSyntax = 
+    if(transitions.isEmpty){
+      sqls"resultId"
+    } else {
+      transitions.map { _.stateUpdateSyntax }
+                 .foldLeft(sqls"case") { _ + sqls" " + _ } + sqls" else state end"
+    }
+
+}

--- a/src/test/scala/info/vizierdb/api/ProjectAPISpec.scala
+++ b/src/test/scala/info/vizierdb/api/ProjectAPISpec.scala
@@ -62,7 +62,7 @@ class ProjectAPISpec
     val deleteResponse = DeleteProjectHandler.handle(Map("projectId" -> JsNumber(id)))
 
     DB.readOnly { implicit s => 
-      Project.lookup(id) must beNone
+      Project.getOption(id) must beNone
     }
   }
 

--- a/src/test/scala/info/vizierdb/viztrails/ViztrailsSpec.scala
+++ b/src/test/scala/info/vizierdb/viztrails/ViztrailsSpec.scala
@@ -38,7 +38,7 @@ class ViztrailsSpec
     }
 
     DB autoCommit { implicit session =>
-      val project = Project.lookup(id).getOrElse {
+      val project = Project.getOption(id).getOrElse {
                         ko("newly created project doesn't exist"); null
                       }
       project.name must be equalTo("Test Project")


### PR DESCRIPTION
- Formalizing a notion of a State Transition (viztrails.StateTransition)
  as discussed here: https://github.com/VizierDB/vizier-scala/wiki/DevGuide-CellStates
- Migrated Branch head updates, Workflow.abort, and Scheduler.errorResult
  to use the new State Transition model (NOTE: it would be nice to also
  incorporate this into the DeltaBus as well...)
- Consistency in naming: CatalogObject.lookup is now CatalogObject.getOption
- AppendModule now aborts the workflow (this needs to happen for the other state change calls
- Branch operations are now fully commented.
- Moved the discussion of the cell state model to a canonical place on the
  project wiki.
- ExecutionState now has several sets describing different categories of
  states (PENDING, PROVENANCE_VALID, etc...)
- Turns out we weren't using the BLOCKED state.  Removing it.