### PR TITLE
Flipped coordinates for heatmap image overlays.

### DIFF
--- a/src/main/scala/info/vizierdb/commands/plot/GeoPlot.scala
+++ b/src/main/scala/info/vizierdb/commands/plot/GeoPlot.scala
@@ -324,7 +324,7 @@ object GeoPlot extends Command
 
     s"""
     |{
-    |  let layer = L.imageOverlay('${layer.url}', [[${envelope.getMinX()},${envelope.getMinY()}], [${envelope.getMaxX()},${envelope.getMaxY()}]])
+    |  let layer = L.imageOverlay('${layer.url}', [[${envelope.getMinY()},${envelope.getMinX()}], [${envelope.getMaxY()},${envelope.getMaxX()}]])
     |  layer.addTo(theMap)
     |}
     """.stripMargin


### PR DESCRIPTION
# Changes
Flipped coordinates for heatmap image overlays in `GeoPlot.scala`

# Result of changes
Heat-maps using geo-plotted data should now be displayed over the proper area specified from coordinates, progress towards #124 .